### PR TITLE
Add FMNIST and GTS datasets

### DIFF
--- a/robustml/dataset.py
+++ b/robustml/dataset.py
@@ -33,6 +33,32 @@ class MNIST(Dataset):
     def labels(self):
         return 10
 
+class FMNIST(Dataset):
+    '''
+    Data points are 28x28 arrays with elements in [0, 1].
+    '''
+
+    @property
+    def shape(self):
+        return (28, 28)
+
+    @property
+    def labels(self):
+        return 10
+
+class GTS(Dataset):
+    '''
+    Data points are 32x32x3 arrays with elements in [0, 1].
+    '''
+
+    @property
+    def shape(self):
+        return (32, 32, 3)
+
+    @property
+    def labels(self):
+        return 43
+
 class CIFAR10(Dataset):
     '''
     Data points are 32x32x3 arrays with elements in [0, 1].


### PR DESCRIPTION
Hi,
I added FMNIST and GTS datasets (based on this request https://github.com/robust-ml/robust-ml.github.io/issues/5).
In my implementation, I directly use the official sources for both FMNIST and GTS.

Note that for GTS I apply 32x32 resizing of the original images that are of different size originally - from 15x15 to 200x200. I'm not aware of any established standard regarding the unified size of GTS used in the literature (well, in fact, this dataset is used not so often). Therefore, we decided to just make it comparable to the size of CIFAR-10. This preserves all the necessary details in the images.

Thanks.